### PR TITLE
Add `Table::iter_bytes`, `Table::scan_bytes` and `Table::size_bytes`

### DIFF
--- a/tests/table.rs
+++ b/tests/table.rs
@@ -2,6 +2,7 @@ extern crate sled;
 extern crate sled_table;
 
 use sled_table::Table;
+use std::mem;
 
 // A type that we may use as a test `Table`.
 pub struct ByteTable;
@@ -17,10 +18,10 @@ impl Table for ByteTable {
 #[test]
 fn test_writer() {
     let config = sled::ConfigBuilder::new().temporary(true).build();
-    let t = sled::Tree::start(config).unwrap();
+    let tree = sled::Tree::start(config).unwrap();
 
     // Writer::from
-    let table = sled_table::Writer::<ByteTable>::from(&t);
+    let table = sled_table::Writer::<ByteTable>::from(&tree);
 
     // Writer::set/get
     let a_key = vec![1, 2, 3, 4];
@@ -34,17 +35,62 @@ fn test_writer() {
 
     // Writer::iter
     let mut iter = table.iter().unwrap();
-    assert_eq!(iter.next().unwrap().unwrap(), (b_key.clone(), b_value.clone()));
-    assert_eq!(iter.next().unwrap().unwrap(), (a_key.clone(), a_value.clone()));
+    assert_eq!(
+        iter.next().unwrap().unwrap(),
+        (b_key.clone(), b_value.clone())
+    );
+    assert_eq!(
+        iter.next().unwrap().unwrap(),
+        (a_key.clone(), a_value.clone())
+    );
     assert!(iter.next().is_none());
 
     // Writer::scan
     let mut iter = table.scan(&vec![1, 2, 3, 1]).unwrap();
-    assert_eq!(iter.next().unwrap().unwrap(), (a_key.clone(), a_value.clone()));
+    assert_eq!(
+        iter.next().unwrap().unwrap(),
+        (a_key.clone(), a_value.clone())
+    );
     assert!(iter.next().is_none());
 
     // Writer::del
     assert_eq!(table.del(&a_key).unwrap().unwrap(), a_value);
     assert_eq!(table.del(&b_key).unwrap().unwrap(), b_value);
     assert_eq!(table.del(&b_key).unwrap(), None);
+}
+
+#[test]
+fn test_table_size_bytes() {
+    let config = sled::ConfigBuilder::new().temporary(true).build();
+    let tree = sled::Tree::start(config).unwrap();
+    let table = sled_table::Writer::<ByteTable>::from(&tree);
+
+    // Size with one entry.
+    let a_key = vec![1, 2, 3, 4];
+    let a_value = vec![5, 6, 7, 8];
+    table.set(&a_key, &a_value).unwrap();
+    let expected_a = mem::size_of::<<ByteTable as Table>::Id>() // a_key prepended table ID
+        + a_key.len()
+        + mem::size_of::<usize>() // length of a_value
+        + a_value.len();
+    assert_eq!(table.size_bytes().unwrap(), expected_a);
+
+    // Size with two entries.
+    let b_key = vec![1, 2, 3, 0];
+    let b_value = vec![0];
+    table.set(&b_key, &b_value).unwrap();
+    let expected_b = mem::size_of::<<ByteTable as Table>::Id>() // a_key prepended table ID
+        + a_key.len()
+        + mem::size_of::<usize>() // length of a_value
+        + a_value.len()
+        + mem::size_of::<<ByteTable as Table>::Id>() // b_key prepended table ID
+        + b_key.len()
+        + mem::size_of::<usize>() // length of b_value
+        + b_value.len();
+    assert_eq!(table.size_bytes().unwrap(), expected_b);
+
+    // Size with second entry removed.
+    table.del(&b_key).unwrap();
+    assert_eq!(table.size_bytes().unwrap(), expected_a);
+    assert_eq!(table.size_bytes().unwrap(), sled_table::tree_size_bytes(&tree).unwrap());
 }


### PR DESCRIPTION
This allows for iterating over the raw, serialized bytes for each entry
in the table. The `Table::iter` and `Table::scan` implementations have
been simplified by using these new methods internally.

This allows for the easy calculation of the size of a table in bytes,
implemented as `Table::size_bytes`. A similar function called
`tree_size_bytes` has been added to the root for calculating the size of
a full `sled::Tree`.

Tests have been added for all of the above.